### PR TITLE
External plugin requires packet_info

### DIFF
--- a/libpcap-analyzer/src/lib.rs
+++ b/libpcap-analyzer/src/lib.rs
@@ -6,7 +6,7 @@ extern crate log;
 
 mod flow_map;
 mod layers;
-mod packet_info;
+pub mod packet_info;
 pub use flow_map::FlowMap;
 pub use layers::*;
 

--- a/libpcap-tools/Cargo.toml
+++ b/libpcap-tools/Cargo.toml
@@ -26,5 +26,5 @@ thiserror = "1.0"
 toml="0.5"
 
 [dependencies.pcap-parser]
-version = "0.13.0"
+version = "0.13.1"
 features = ["data"]


### PR DESCRIPTION
Proposing 2 fixes we ran across:
* A recent change to libpcap-tools on your master branch requires pcap-parser 0.13.1 but Cargo.toml was not updated to match.
* Expose packet_info as public so external plugins can access packet information they require.
