### PR TITLE
Provide alternative when fasthash is not available

### DIFF
--- a/libpcap-analyzer/Cargo.toml
+++ b/libpcap-analyzer/Cargo.toml
@@ -20,7 +20,7 @@ is-it-maintained-open-issues      = { repository = "rusticata/pcap-analyzer" }
 maintenance                       = { status     = "actively-developed" }
 
 [features]
-default = ["release"]
+default = ["release", "dep:fasthash"]
 release = ["plugin_community_id", "plugin_ospf", "plugin_rusticata", "plugin_tls_stats"]
 all = ["release", "plugins_debug", "plugin_examples"]
 plugin_community_id = ["sha1", "base16ct", "base64ct"]
@@ -34,7 +34,7 @@ plugin_tls_stats = ["rusticata","tls-parser"]
 base16ct = { version="0.1", features=["alloc"], optional=true }
 base64ct = { version="1.5", features=["alloc"], optional=true }
 crossbeam-channel = "0.5"
-fasthash = "0.4"
+fasthash = { version = "0.4", optional=true }
 fnv = "1.0"
 indexmap = { version="1.1", features=["serde-1"] }
 lazy_static = "1.2"

--- a/libpcap-analyzer/src/threaded_analyzer.rs
+++ b/libpcap-analyzer/src/threaded_analyzer.rs
@@ -238,7 +238,9 @@ fn fan_out(data: &[u8], ethertype: EtherType, n_workers: usize) -> usize {
                 //         sz = 12;
                 //     }
                 // }
-                // let hash = crate::toeplitz::toeplitz_hash(crate::toeplitz::KEY, &buf[..sz]);
+                #[cfg(not(feature = "fasthash"))]
+                let hash = crate::toeplitz::toeplitz_hash(crate::toeplitz::KEY, &buf[..sz]);
+                #[cfg(feature = "fasthash")]
                 let hash = fasthash::metro::hash64(&buf[..sz]);
                 // debug!("{:?} -- hash --> 0x{:x}", buf, hash);
                 // ((hash >> 24) ^ (hash & 0xff)) as usize % n_workers
@@ -270,7 +272,9 @@ fn fan_out(data: &[u8], ethertype: EtherType, n_workers: usize) -> usize {
                 //         sz += 4;
                 //     }
                 // }
-                // let hash = crate::toeplitz::toeplitz_hash(crate::toeplitz::KEY, &buf[..sz]);
+                #[cfg(not(feature = "fasthash"))]
+                let hash = crate::toeplitz::toeplitz_hash(crate::toeplitz::KEY, &buf[..sz]);
+                #[cfg(feature = "fasthash")]
                 let hash = fasthash::metro::hash64(&buf[..sz]);
                 // debug!("{:?} -- hash --> 0x{:x}", buf, hash);
                 // ((hash >> 24) ^ (hash & 0xff)) as usize % n_workers


### PR DESCRIPTION
https://github.com/rusticata/pcap-analyzer/issues/6

Fasthash does not build on aarch64 currently.  There were commented out alternatives to where Fasthash is used.  This just makes them easier to toggle/slightly more discoverable.