### PR TITLE
pacp-rewrite: add warn! with ctx.pcap_index

### DIFF
--- a/pcap-rewrite/src/filters/dispatch_filter.rs
+++ b/pcap-rewrite/src/filters/dispatch_filter.rs
@@ -54,6 +54,7 @@ impl<Container, Key> DispatchFilter<Container, Key> {
         let key_option = match packet_data {
             PacketData::L2(data) => {
                 if data.len() < 14 {
+                    warn!("L2 data too small for ethernet at index {}", ctx.pcap_index);
                     return Err(Error::DataParser("L2 data too small for ethernet"));
                 }
 
@@ -74,7 +75,8 @@ impl<Container, Key> DispatchFilter<Container, Key> {
                     EtherTypes::Lldp => None,
                     _ => {
                         warn!(
-                            "Unimplemented Ethertype in L3 {:?}/{:x}",
+                            "Unimplemented Ethertype in L3 at index {}: {:?}/{:x}",
+                            ctx.pcap_index,
                             ether_type,
                             ether_type.to_primitive_values().0
                         );

--- a/pcap-rewrite/src/filters/fragmentation/fragmentation_filter.rs
+++ b/pcap-rewrite/src/filters/fragmentation/fragmentation_filter.rs
@@ -74,6 +74,7 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
         let is_first_fragment = match packet.data {
             PacketData::L2(data) => {
                 if data.len() < 14 {
+                    warn!("L2 data too small for ethernet at index {}", ctx.pcap_index);
                     return Err(Error::DataParser("L2 data too small for ethernet"));
                 }
 
@@ -97,8 +98,8 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
                     EtherTypes::Lldp => false,
                     _ => {
                         warn!(
-                            "Unimplemented Ethertype in L3: {:?}/{:x}",
-                            ether_type, ether_type.0
+                            "Unimplemented Ethertype in L3 at index {}: {:?}/{:x}",
+                            ctx.pcap_index, ether_type, ether_type.0
                         );
                         return Err(Error::Unimplemented("Unimplemented EtherType in L3"));
                     }
@@ -112,6 +113,7 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
             let data_option: Option<TwoTupleProtoIpidFiveTuple> = match packet.data {
                 PacketData::L2(data) => {
                     if data.len() < 14 {
+                        warn!("L2 data too small for ethernet at index {}", ctx.pcap_index);
                         return Err(Error::DataParser("L2 data too small for ethernet"));
                     }
 
@@ -136,8 +138,8 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
                         EtherTypes::Lldp => None,
                         _ => {
                             warn!(
-                                "Unimplemented Ethertype in L3: {:?}/{:x}",
-                                ether_type, ether_type.0
+                                "Unimplemented Ethertype in L3 at index {}: {:?}/{:x}",
+                                ctx.pcap_index, ether_type, ether_type.0
                             );
                             return Err(Error::Unimplemented("Unimplemented Ethertype in L3"));
                         }
@@ -148,7 +150,9 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
             };
 
             match data_option {
-                None => Err("Could find a first IP fragment but could not two tuple/proto/IP id")?,
+                None => Err(Error::DataParser(
+                    "Could find a first IP fragment but could not find two tuple/proto/IP id",
+                ))?,
                 Some(data) => self.data_hs.insert(data),
             };
         }
@@ -163,6 +167,7 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
         let key_option = match packet_data {
             PacketData::L2(data) => {
                 if data.len() < 14 {
+                    warn!("L2 data too small for ethernet at index {}", ctx.pcap_index);
                     return Err(Error::DataParser("L2 data too small for ethernet"));
                 }
 
@@ -183,8 +188,8 @@ impl<Container, Key> FragmentationFilter<Container, Key> {
                     EtherTypes::Lldp => None,
                     _ => {
                         warn!(
-                            "Unimplemented Ethertype in L3: {:?}/{:x}",
-                            ether_type, ether_type.0
+                            "Unimplemented Ethertype in L3 at index {}: {:?}/{:x}",
+                            ctx.pcap_index, ether_type, ether_type.0
                         );
                         return Err(Error::Unimplemented("Unimplemented Ethertype in L3"));
                     }

--- a/pcap-rewrite/src/filters/fragmentation/fragmentation_test.rs
+++ b/pcap-rewrite/src/filters/fragmentation/fragmentation_test.rs
@@ -1,13 +1,19 @@
 use libpcap_tools::{Error, ParseContext};
 
+use log::warn;
 use pnet_packet::ipv4::Ipv4Packet;
 use pnet_packet::ipv6::Ipv6Packet;
 
 use crate::filters::ipv6_utils;
 
-pub fn is_ipv4_first_fragment(_ctx: &ParseContext, payload: &[u8]) -> Result<bool, Error> {
-    let ipv4_packet =
-        Ipv4Packet::new(payload).ok_or(Error::Pnet("Expected Ipv4 packet but could not parse"))?;
+pub fn is_ipv4_first_fragment(ctx: &ParseContext, payload: &[u8]) -> Result<bool, Error> {
+    let ipv4_packet = Ipv4Packet::new(payload).ok_or_else(|| {
+        warn!(
+            "Expected Ipv4 packet but could not parse at index {}",
+            ctx.pcap_index
+        );
+        Error::Pnet("Expected Ipv4 packet but could not parse")
+    })?;
     let flags = ipv4_packet.get_flags();
     let fragment_offset = ipv4_packet.get_fragment_offset();
 
@@ -16,9 +22,14 @@ pub fn is_ipv4_first_fragment(_ctx: &ParseContext, payload: &[u8]) -> Result<boo
     Ok(mf_flag == 1 && fragment_offset == 0)
 }
 
-pub fn is_ipv6_first_fragment(_ctx: &ParseContext, payload: &[u8]) -> Result<bool, Error> {
-    let ipv6_packet =
-        Ipv6Packet::new(payload).ok_or(Error::Pnet("Expected Ipv6 packet but could not parse"))?;
+pub fn is_ipv6_first_fragment(ctx: &ParseContext, payload: &[u8]) -> Result<bool, Error> {
+    let ipv6_packet = Ipv6Packet::new(payload).ok_or_else(|| {
+        warn!(
+            "Expected Ipv6 packet but could not parse at index {}",
+            ctx.pcap_index
+        );
+        Error::Pnet("Expected Ipv6 packet but could not parse")
+    })?;
     let (fragment_packet_option, _l4_proto, _payload) =
         ipv6_utils::get_fragment_packet_option_l4_protol4_payload(payload, &ipv6_packet)?;
     match fragment_packet_option {


### PR DESCRIPTION
This commit adds a warning message "warn!()" that display ctx.pcap_index for each parsing error (either internal pnet or pcap-rewrite code).