### PR TITLE
pcap-rewrite: improve filtering key types

### DIFF
--- a/pcap-rewrite/src/filters/dispatch_filter.rs
+++ b/pcap-rewrite/src/filters/dispatch_filter.rs
@@ -6,12 +6,11 @@ use std::path::Path;
 use libpcap_tools::{Error, FiveTuple, ParseContext};
 use pcap_parser::data::PacketData;
 use pnet_packet::ethernet::{EtherType, EtherTypes};
-use pnet_packet::ip::IpNextHeaderProtocol;
 use pnet_packet::PrimitiveValues;
 
 use crate::container::five_tuple_container::FiveTupleC;
 use crate::container::ipaddr_container::IpAddrC;
-use crate::container::ipaddr_proto_port_container::IpAddrProtoPortC;
+use crate::container::ipaddr_proto_port_container::{IpAddrProtoPort, IpAddrProtoPortC};
 use crate::filters::filter::{FResult, Filter, Verdict};
 use crate::filters::filter_utils;
 use crate::filters::filtering_action::FilteringAction;
@@ -180,15 +179,14 @@ impl DispatchFilterBuilder {
                     IpAddrProtoPortC::of_file_path(Path::new(key_file_path))
                         .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
-                let keep: KeepFn<IpAddrProtoPortC, (IpAddr, IpNextHeaderProtocol, u16)> =
-                    match filtering_action {
-                        FilteringAction::Keep => {
-                            Box::new(|c, tuple| Ok(c.contains(&tuple.0, &tuple.1, tuple.2)))
-                        }
-                        FilteringAction::Drop => {
-                            Box::new(|c, tuple| Ok(!c.contains(&tuple.0, &tuple.1, tuple.2)))
-                        }
-                    };
+                let keep: KeepFn<IpAddrProtoPortC, IpAddrProtoPort> = match filtering_action {
+                    FilteringAction::Keep => {
+                        Box::new(|c, ipaddr_proto_port| Ok(c.contains(ipaddr_proto_port)))
+                    }
+                    FilteringAction::Drop => {
+                        Box::new(|c, ipaddr_proto_port| Ok(!c.contains(ipaddr_proto_port)))
+                    }
+                };
 
                 Ok(Box::new(DispatchFilter::new(
                     ipaddr_proto_port_container,

--- a/pcap-rewrite/src/filters/dispatch_filter.rs
+++ b/pcap-rewrite/src/filters/dispatch_filter.rs
@@ -15,6 +15,7 @@ use crate::filters::filter::{FResult, Filter, Verdict};
 use crate::filters::filter_utils;
 use crate::filters::filtering_action::FilteringAction;
 use crate::filters::filtering_key::FilteringKey;
+use crate::filters::ipaddr_pair::IpAddrPair;
 use crate::filters::key_parser_ipv4;
 use crate::filters::key_parser_ipv6;
 
@@ -158,12 +159,12 @@ impl DispatchFilterBuilder {
                 let ipaddr_container = IpAddrC::of_file_path(Path::new(key_file_path))
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
-                let keep: KeepFn<IpAddrC, (IpAddr, IpAddr)> = match filtering_action {
-                    FilteringAction::Keep => Box::new(|c, ipaddr_tuple| {
-                        Ok(c.contains(&ipaddr_tuple.0) || c.contains(&ipaddr_tuple.1))
+                let keep: KeepFn<IpAddrC, IpAddrPair> = match filtering_action {
+                    FilteringAction::Keep => Box::new(|c, ipaddr_pair| {
+                        Ok(c.contains(&ipaddr_pair.0) || c.contains(&ipaddr_pair.1))
                     }),
-                    FilteringAction::Drop => Box::new(|c, ipaddr_tuple| {
-                        Ok(!c.contains(&ipaddr_tuple.0) && !c.contains(&ipaddr_tuple.1))
+                    FilteringAction::Drop => Box::new(|c, ipaddr_pair| {
+                        Ok(!c.contains(&ipaddr_pair.0) && !c.contains(&ipaddr_pair.1))
                     }),
                 };
 

--- a/pcap-rewrite/src/filters/fragmentation/convert_fn.rs
+++ b/pcap-rewrite/src/filters/fragmentation/convert_fn.rs
@@ -7,7 +7,7 @@ use libpcap_tools::FiveTuple;
 
 use crate::container::five_tuple_container::FiveTupleC;
 use crate::container::ipaddr_container::IpAddrC;
-use crate::container::ipaddr_proto_port_container::IpAddrProtoPortC;
+use crate::container::ipaddr_proto_port_container::{IpAddrProtoPort, IpAddrProtoPortC};
 use crate::container::two_tuple_proto_ipid_container::TwoTupleProtoIpidC;
 use crate::filters::fragmentation::two_tuple_proto_ipid_five_tuple::TwoTupleProtoIpidFiveTuple;
 
@@ -51,7 +51,7 @@ pub fn convert_data_hs_to_src_ipaddr_proto_dst_port_container(
         .iter()
         .filter_map(|t| t.get_five_tuple_option())
         .map(|five_tuple| {
-            (
+            IpAddrProtoPort::new(
                 five_tuple.src,
                 IpNextHeaderProtocol::new(five_tuple.proto),
                 five_tuple.dst_port,
@@ -61,7 +61,7 @@ pub fn convert_data_hs_to_src_ipaddr_proto_dst_port_container(
         .iter()
         .filter_map(|t| t.get_five_tuple_option())
         .map(|five_tuple| {
-            (
+            IpAddrProtoPort::new(
                 five_tuple.dst,
                 IpNextHeaderProtocol::new(five_tuple.proto),
                 five_tuple.src_port,

--- a/pcap-rewrite/src/filters/fragmentation/fragmentation_filter.rs
+++ b/pcap-rewrite/src/filters/fragmentation/fragmentation_filter.rs
@@ -17,11 +17,11 @@ use crate::filters::filter::{FResult, Verdict};
 use crate::filters::filter_utils;
 use crate::filters::filtering_action::FilteringAction;
 use crate::filters::filtering_key::FilteringKey;
-use crate::filters::key_parser_ipv4;
-use crate::filters::key_parser_ipv6;
-
 use crate::filters::fragmentation::fragmentation_test;
 use crate::filters::fragmentation::two_tuple_proto_ipid_five_tuple::TwoTupleProtoIpidFiveTuple;
+use crate::filters::ipaddr_pair::IpAddrPair;
+use crate::filters::key_parser_ipv4;
+use crate::filters::key_parser_ipv6;
 
 use super::convert_fn;
 
@@ -297,12 +297,12 @@ impl FragmentationFilterBuilder {
             FilteringKey::SrcDstIpaddr => {
                 let ipaddr_container = IpAddrC::new(HashSet::new());
 
-                let keep: KeepFn<IpAddrC, (IpAddr, IpAddr)> = match filtering_action {
-                    FilteringAction::Keep => |c, ipaddr_tuple| {
-                        Ok(c.contains(&ipaddr_tuple.0) || c.contains(&ipaddr_tuple.1))
-                    },
-                    FilteringAction::Drop => |c, ipaddr_tuple| {
-                        Ok(!c.contains(&ipaddr_tuple.0) && !c.contains(&ipaddr_tuple.1))
+                let keep: KeepFn<IpAddrC, IpAddrPair> = match filtering_action {
+                    FilteringAction::Keep => {
+                        |c, ipaddr_pair| Ok(c.contains(&ipaddr_pair.0) || c.contains(&ipaddr_pair.1))
+                    }
+                    FilteringAction::Drop => |c, ipaddr_pair| {
+                        Ok(!c.contains(&ipaddr_pair.0) && !c.contains(&ipaddr_pair.1))
                     },
                 };
 

--- a/pcap-rewrite/src/filters/ipaddr_pair.rs
+++ b/pcap-rewrite/src/filters/ipaddr_pair.rs
@@ -1,0 +1,9 @@
+use std::net::IpAddr;
+
+pub struct IpAddrPair (pub IpAddr,pub IpAddr);
+
+impl IpAddrPair {
+    pub fn new(ipaddr_0: IpAddr, ipaddr_1: IpAddr) -> IpAddrPair {
+        IpAddrPair (ipaddr_0, ipaddr_1 )
+    }
+}

--- a/pcap-rewrite/src/filters/key_parser_ipv4.rs
+++ b/pcap-rewrite/src/filters/key_parser_ipv4.rs
@@ -12,6 +12,7 @@ use libpcap_tools::{Error, FiveTuple, ParseContext};
 use super::fragmentation::two_tuple_proto_ipid::TwoTupleProtoIpid;
 use super::fragmentation::two_tuple_proto_ipid_five_tuple::TwoTupleProtoIpidFiveTuple;
 use crate::container::ipaddr_proto_port_container::IpAddrProtoPort;
+use crate::filters::ipaddr_pair::IpAddrPair;
 
 pub fn parse_src_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddr, Error> {
     let ipv4 = Ipv4Packet::new(payload).ok_or_else(|| {
@@ -35,7 +36,7 @@ pub fn parse_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddr, Er
     Result::Ok(IpAddr::V4(ipv4.get_destination()))
 }
 
-pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<(IpAddr, IpAddr), Error> {
+pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddrPair, Error> {
     let ipv4_packet = Ipv4Packet::new(payload).ok_or_else(|| {
         warn!(
             "Expected Ipv4 packet but could not parse at index {}",
@@ -45,7 +46,7 @@ pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<(IpAdd
     })?;
     let src_ipaddr = IpAddr::V4(ipv4_packet.get_source());
     let dst_ipaddr = IpAddr::V4(ipv4_packet.get_destination());
-    Result::Ok((src_ipaddr, dst_ipaddr))
+    Result::Ok(IpAddrPair::new(src_ipaddr, dst_ipaddr))
 }
 
 pub fn parse_src_ipaddr_proto_dst_port(

--- a/pcap-rewrite/src/filters/key_parser_ipv6.rs
+++ b/pcap-rewrite/src/filters/key_parser_ipv6.rs
@@ -12,6 +12,7 @@ use libpcap_tools::{Error, FiveTuple, ParseContext};
 
 use super::fragmentation::two_tuple_proto_ipid::TwoTupleProtoIpid;
 use super::fragmentation::two_tuple_proto_ipid_five_tuple::TwoTupleProtoIpidFiveTuple;
+use crate::filters::ipaddr_pair::IpAddrPair;
 
 pub fn parse_src_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddr, Error> {
     let ipv6 = Ipv6Packet::new(payload).ok_or_else(|| {
@@ -35,7 +36,7 @@ pub fn parse_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddr, Er
     Ok(IpAddr::V6(ipv6.get_destination()))
 }
 
-pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<(IpAddr, IpAddr), Error> {
+pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<IpAddrPair, Error> {
     let ipv6_packet = Ipv6Packet::new(payload).ok_or_else(|| {
         warn!(
             "Expected Ipv6 packet but could not parse at index {}",
@@ -45,7 +46,7 @@ pub fn parse_src_dst_ipaddr(ctx: &ParseContext, payload: &[u8]) -> Result<(IpAdd
     })?;
     let src_ipaddr = IpAddr::V6(ipv6_packet.get_source());
     let dst_ipaddr = IpAddr::V6(ipv6_packet.get_destination());
-    Result::Ok((src_ipaddr, dst_ipaddr))
+    Result::Ok(IpAddrPair::new(src_ipaddr, dst_ipaddr))
 }
 
 pub fn parse_src_ipaddr_proto_dst_port(

--- a/pcap-rewrite/src/filters/mod.rs
+++ b/pcap-rewrite/src/filters/mod.rs
@@ -5,6 +5,7 @@ pub mod filter_utils;
 pub mod filtering_action;
 pub mod filtering_key;
 pub mod fragmentation;
+pub mod ipaddr_pair;
 pub mod ipv6_utils;
 pub mod key_parser_ipv4;
 pub mod key_parser_ipv6;


### PR DESCRIPTION
Replace IpAddr tuple by IpAddrPair and IpAddr, Proto, Port tuple by record.