### PR TITLE
pcap-rewrite: split first fragment/packet keys for five tuple flow

### DIFF
--- a/pcap-rewrite/src/filters/dispatch_filter.rs
+++ b/pcap-rewrite/src/filters/dispatch_filter.rs
@@ -200,9 +200,13 @@ impl DispatchFilterBuilder {
                 let five_tuple_container = FiveTupleC::of_file_path(Path::new(key_file_path))
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
-                let keep: KeepFn<FiveTupleC, FiveTuple> = match filtering_action {
-                    FilteringAction::Keep => Box::new(|c, five_tuple| Ok(c.contains(five_tuple))),
-                    FilteringAction::Drop => Box::new(|c, five_tuple| Ok(!c.contains(five_tuple))),
+                let keep: KeepFn<FiveTupleC, Option<FiveTuple>> = match filtering_action {
+                    FilteringAction::Keep => Box::new(|c, five_tuple_option| {
+                        Ok(five_tuple_option.as_ref().map_or(false, |five_tuple| c.contains(five_tuple)))
+                    }),
+                    FilteringAction::Drop => Box::new(|c, five_tuple_option| {
+                        Ok(five_tuple_option.as_ref().map_or(false, |five_tuple| !c.contains(five_tuple)))
+                    }),
                 };
 
                 Ok(Box::new(DispatchFilter::new(

--- a/pcap-rewrite/src/filters/fragmentation/key_fragmentation_matching.rs
+++ b/pcap-rewrite/src/filters/fragmentation/key_fragmentation_matching.rs
@@ -1,0 +1,31 @@
+use libpcap_tools::FiveTuple;
+
+use crate::filters::fragmentation::two_tuple_proto_ipid::TwoTupleProtoIpid;
+
+/// Contains either FiveTuple or TwoTupleProtoIpid.
+/// It is used to store data that will be matched against the data of the first fragment.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum KeyFragmentationMatching {
+    /// Packet is either not a fragment, or the first one.
+    NotFragmentOrFirstFragment(FiveTuple),
+    /// Packet is a fragment, but not the first one.
+    FragmentAfterFirst(TwoTupleProtoIpid),
+}
+
+impl KeyFragmentationMatching {
+    pub fn get_two_tuple_proto_ipid_option(&self) -> Option<&TwoTupleProtoIpid> {
+        match self {
+            KeyFragmentationMatching::FragmentAfterFirst(two_tuple_proto_ipid) => {
+                Some(two_tuple_proto_ipid)
+            }
+            KeyFragmentationMatching::NotFragmentOrFirstFragment(_) => None,
+        }
+    }
+
+    pub fn get_five_tuple_option(&self) -> Option<&FiveTuple> {
+        match self {
+            KeyFragmentationMatching::FragmentAfterFirst(_) => None,
+            KeyFragmentationMatching::NotFragmentOrFirstFragment(five_tuple) => Some(five_tuple),
+        }
+    }
+}

--- a/pcap-rewrite/src/filters/fragmentation/mod.rs
+++ b/pcap-rewrite/src/filters/fragmentation/mod.rs
@@ -3,3 +3,4 @@ pub mod fragmentation_filter;
 pub mod fragmentation_test;
 pub mod two_tuple_proto_ipid;
 pub mod two_tuple_proto_ipid_five_tuple;
+pub mod key_fragmentation_matching;

--- a/pcap-rewrite/src/filters/fragmentation/two_tuple_proto_ipid_five_tuple.rs
+++ b/pcap-rewrite/src/filters/fragmentation/two_tuple_proto_ipid_five_tuple.rs
@@ -2,9 +2,13 @@ use libpcap_tools::FiveTuple;
 
 use crate::filters::fragmentation::two_tuple_proto_ipid::TwoTupleProtoIpid;
 
+/// Contains both FiveTuple or TwoTupleProtoIpid.
+/// It is used to store data from the first fragment.
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct TwoTupleProtoIpidFiveTuple {
+    /// Src/dst/proto/IP ID of the first fragment
     two_tuple_proto_ipid_option: Option<TwoTupleProtoIpid>,
+    /// Five tuple of the first fragment
     five_tuple_option: Option<FiveTuple>,
 }
 


### PR DESCRIPTION
split key data used for first fragment and data filtered against this first fragment for five tuple flow