### PR TITLE
pcap-rewrite: add more genericity to KeyFragmentationTransport

### DIFF
--- a/pcap-rewrite/src/filters/dispatch_filter.rs
+++ b/pcap-rewrite/src/filters/dispatch_filter.rs
@@ -202,10 +202,14 @@ impl DispatchFilterBuilder {
 
                 let keep: KeepFn<FiveTupleC, Option<FiveTuple>> = match filtering_action {
                     FilteringAction::Keep => Box::new(|c, five_tuple_option| {
-                        Ok(five_tuple_option.as_ref().map_or(false, |five_tuple| c.contains(five_tuple)))
+                        Ok(five_tuple_option
+                            .as_ref()
+                            .map_or(false, |five_tuple| c.contains(five_tuple)))
                     }),
                     FilteringAction::Drop => Box::new(|c, five_tuple_option| {
-                        Ok(five_tuple_option.as_ref().map_or(false, |five_tuple| !c.contains(five_tuple)))
+                        Ok(five_tuple_option
+                            .as_ref()
+                            .map_or(false, |five_tuple| !c.contains(five_tuple)))
                     }),
                 };
 

--- a/pcap-rewrite/src/filters/fragmentation/convert_fn.rs
+++ b/pcap-rewrite/src/filters/fragmentation/convert_fn.rs
@@ -72,7 +72,7 @@ pub fn convert_data_hs_to_src_ipaddr_proto_dst_port_container(
     IpAddrProtoPortC::new(ipaddr_proto_port_hs)
 }
 
-pub fn convert_data_hs_to_ctuple(
+pub fn convert_data_hs_to_two_tuple_proto_ipid_c_five_tuple_c(
     data_hs: &HashSet<TwoTupleProtoIpidFiveTuple>,
 ) -> (TwoTupleProtoIpidC, FiveTupleC) {
     let two_tuple_proto_ipid_hs: HashSet<_> = data_hs


### PR DESCRIPTION
add genericity to KeyFragmentationTransport parsing and container checking